### PR TITLE
Update to Bevy 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased - XXXX-XX-XX
+- Migrate to bevy 0.18
+
 ## v0.5.2 - 2025-10-6
 - Fix documentation
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ categories = [ "game-development" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_time = { version = "0.17.2", default-features = false }
-bevy_ecs = { version = "0.17.2", default-features = false }
-bevy_app = { version = "0.17.2", default-features = false, optional = true }
-bevy_reflect = { version = "0.17.2", default-features = false, optional = true }
+bevy_time = { version = "0.18.0", default-features = false }
+bevy_ecs = { version = "0.18.0", default-features = false }
+bevy_app = { version = "0.18.0", default-features = false, optional = true }
+bevy_reflect = { version = "0.18.0", default-features = false, optional = true }
 
 [features]
 default = [
@@ -28,7 +28,7 @@ bevy_reflect = [ "dep:bevy_reflect", "bevy_ecs/bevy_reflect", "bevy_app/bevy_ref
 bevy_app = [ "dep:bevy_app" ]
 
 [dev-dependencies]
-bevy = { version = "0.17.2" , default-features = false }
+bevy = { version = "0.18.0" , default-features = false }
 
 [build-dependencies]
 rustc_version = "0.4.1"


### PR DESCRIPTION
## Summary
- Update all bevy dependencies from 0.17.2 to 0.18.0

## Notes
- No code changes required - just version bumps
- Tested compilation locally